### PR TITLE
Fix some XSS

### DIFF
--- a/avAdmin/admin-directives/create/create.html
+++ b/avAdmin/admin-directives/create/create.html
@@ -9,7 +9,7 @@
       <table class="table table-bordered table-striped">
           <tr>
               <th ng-i18next> avAdmin.basic.description.label </th>
-              <td ng-bind-html="election.description | addTargetBlank"></td>
+              <td ng-bind="election.description | htmlToText | truncate:150"></td>
           </tr>
           <tr>
               <th ng-i18next> avAdmin.sidebar.questions </th>

--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -26,6 +26,7 @@ angular.module('avAdmin')
       ElectionsApi,
       $state,
       $stateParams,
+      $sanitize,
       $i18next,
       $filter,
       $modal,
@@ -69,11 +70,11 @@ angular.module('avAdmin')
         }
 
         function logInfo(text) {
-          scope.log += "<p>" + text + "</p>";
+          scope.log += "<p>" + $sanitize(text) + "</p>";
         }
 
         function logError(text) {
-          scope.log += "<p class=\"text-brand-danger\">" + text + "</p>";
+          scope.log += "<p class=\"text-brand-danger\">" + $sanitize(text) + "</p>";
         }
         function validateEmail(email) {
           var re = /^[^\s@]+@[^\s@.]+\.[^\s@.]+$/;
@@ -1078,7 +1079,7 @@ angular.module('avAdmin')
               election: el,
               error: function (errorMsg) {
                   scope.errors.push({
-                    data: {message: errorMsg},
+                    data: {message: $sanitize($sanitize)(errorMsg)},
                     key: "election-census-createel-unknown"
                   });
                 },
@@ -1316,7 +1317,7 @@ angular.module('avAdmin')
                   data: scope.elections,
                   onError: function (errorKey, errorData) {
                     scope.errors.push({
-                      data: errorData,
+                      data: $sanitize(errorData),
                       key: errorKey
                     });
                   }

--- a/avAdmin/admin-directives/elections/elections.html
+++ b/avAdmin/admin-directives/elections/elections.html
@@ -84,7 +84,7 @@
               <a ng-click="loadDraft()">
                 <strong>{{ draft.title }}</strong>
                 <div
-                  ng-bind-html="draft.description | htmlToText | truncate:150">
+                  ng-bind="draft.description | htmlToText | truncate:150">
                 </div>
               </a>
             </td>
@@ -122,7 +122,7 @@
               <a ui-sref="admin.dashboard({id: election.id})">
                 <strong>{{ election.title }}</strong>
                 <div
-                  ng-bind-html="election.description | htmlToText | truncate:150">
+                  ng-bind="election.description | htmlToText | truncate:150">
                 </div>
               </a>
               <!-- children elections-->
@@ -142,7 +142,7 @@
                       <a ui-sref="admin.dashboard({id: childElection.id})">
                         <strong>{{ childElection.title }}</strong>
                         <div
-                          ng-bind-html="childElection.description | htmlToText | truncate:150">
+                          ng-bind="childElection.description | htmlToText | truncate:150">
                         </div>
                       </a>
                     </td>


### PR DESCRIPTION
There was an issue with election description. During election creation,
we relied in ng-bind-html to sanitize the visualization of election
description before being sanitized by the backend (because it has not
yet been sent to the backend), but apparently it doesn't work for some
xss. The same issue happened in election list when showing the
description of the drafti election.

With this change, we always show the election description as plain text
so that we don't need to sanitize it. Also see related issue with
htmlToText in common-ui: https://github.com/sequentech/common-ui/pull/221
because sometimes we also called to our own htmlToText angular filter,
and sanitization was also needed to happen there.

Another fix is to use $sanitize more pervasively in the election
creation screen, so that any reply from the server is also not trusted
and properly sanitized.