### PR TITLE
Support HTML format when sending email auth-codes

### DIFF
--- a/SequentConfig.js
+++ b/SequentConfig.js
@@ -58,6 +58,11 @@ var SequentConfigData = {
   // Allowed values: true|false
   allowAdminRegistration: false,
 
+  // For admins:
+  // Allow sending custom html in the email messages sent from the admin console.
+  // Allowed values: true|false
+  allowHtmlEmails: false,
+
   // show the documentation links after successfully casting a vote
   // allowed values: true| false
   showDocOnVoteCast: false,

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
@@ -97,7 +97,7 @@
         </div>
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" ng-if="allowHtmlEmails">
       <label
         class="col-xs-3 control-label text-right padding-top-sm"
         ng-i18next="avAdmin.auth.htmlemail">

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
@@ -97,6 +97,19 @@
         </div>
       </div>
     </div>
+    <div class="form-group">
+      <label
+        class="col-xs-3 control-label text-right padding-top-sm"
+        ng-i18next="avAdmin.auth.htmlemail">
+      </label>
+      <div class="col-xs-9">
+        <div
+          ng-click="editAuthCodes()"
+          class="preview-data preview-body"
+          ng-bind-html="parseMessage(censusConfig.html_message)">
+        </div>
+      </div>
+    </div>
   </div>
   <div class="clearfix"></div>
 </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
@@ -43,6 +43,7 @@ angular.module('avAdmin')
       $scope.loading = false;
       $scope.numVoters = (!!SendMsg.user_ids) ? SendMsg.user_ids.length : $scope.election.auth.census;
       $scope.helpurl = ConfigService.helpUrl;
+      $scope.allowHtmlEmails = ConfigService.allowHtmlEmails;
 
       $scope = _.extend($scope, exhtml.scope);
       $scope.exhtml = exhtml.html;

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -111,10 +111,11 @@
                   </textarea>
               </div>
               <label
+                ng-if="allowHtmlEmails"
                 class="col-xs-3 control-label text-right padding-top-input"
                 ng-i18next="avAdmin.auth.htmlemail">
               </label>
-              <div class="col-xs-9">
+              <div class="col-xs-9" ng-if="allowHtmlEmails">
                   <p class="text-muted" ng-i18next> avAdmin.auth.htmlemailtemp </p>
                   <p
                     class="text-muted"

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -110,6 +110,21 @@
                   >
                   </textarea>
               </div>
+              <div class="col-xs-9">
+                  <p class="text-muted" ng-i18next> avAdmin.auth.htmlemailtemp </p>
+                  <p
+                    class="text-muted"
+                    ng-if="slug_text.length > 0"
+                    ng-i18next
+                  >
+                    [i18next]({slug_list:slug_text})avAdmin.auth.slugKeys
+                  </p>
+                  <textarea
+                    class="form-control"
+                    ng-model="censusConfig.html_message"
+                  >
+                  </textarea>
+              </div>
           </div>
       </div>
     </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -110,6 +110,10 @@
                   >
                   </textarea>
               </div>
+              <label
+                class="col-xs-3 control-label text-right padding-top-input"
+                ng-i18next="avAdmin.auth.htmlemail">
+              </label>
               <div class="col-xs-9">
                   <p class="text-muted" ng-i18next> avAdmin.auth.htmlemailtemp </p>
                   <p

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
@@ -35,6 +35,7 @@ angular
       $scope.steps = SendMsg.steps;
       $scope.censusConfig = SendMsg.censusConfig;
       $scope.helpurl = ConfigService.helpUrl;
+      $scope.allowHtmlEmails = ConfigService.allowHtmlEmails;
       var slug_text = "";
       for (var i = 0; i < SendMsg.slug_list.length; i++) {
         slug_text += (0 !== i? ", " : "" ) + "__" + SendMsg.slug_list[i] + "__";

--- a/avAdmin/admin-directives/elauth/elauth.html
+++ b/avAdmin/admin-directives/elauth/elauth.html
@@ -62,6 +62,15 @@
           help-path="election/auth-email-email/">
                     <textarea class="form-control" id="email-text" ng-model="election.census.config.msg"></textarea>
         </div>
+        <div
+          av-abstract-setting
+          short-value="{{ election.census.config.html_message }}"
+          title="avAdmin.auth.htmlemail"
+          for="email-html"
+          description="avAdmin.auth.htmlemailtemp"
+          help-path="election/auth-email-email/">
+                    <textarea class="form-control" id="email-html" ng-model="election.census.config.html_message"></textarea>
+        </div>
     </div>
 
     <button ng-click="goNext(admin.censusConfig())" ng-if="!election.id" class="btn btn-block btn-success-action" ng-i18next>next</button>

--- a/avAdmin/admin-directives/elauth/elauth.html
+++ b/avAdmin/admin-directives/elauth/elauth.html
@@ -64,6 +64,7 @@
         </div>
         <div
           av-abstract-setting
+          ng-if="allowHtmlEmails"
           short-value="{{ election.census.config.html_message }}"
           title="avAdmin.auth.htmlemail"
           for="email-html"

--- a/avAdmin/admin-directives/elauth/elauth.js
+++ b/avAdmin/admin-directives/elauth/elauth.js
@@ -30,6 +30,7 @@ angular
         function link(scope, element, attrs) 
         {
           scope.election = ElectionsApi.currentElection;
+          scope.allowHtmlEmails = ConfigService.allowHtmlEmails;
           scope.auth = ConfigService.auth_methods;
           scope.electionEditable = function() {
             return !scope.election.id || scope.election.status === "registered";

--- a/locales/en.json
+++ b/locales/en.json
@@ -778,8 +778,10 @@
         "smstemp": "Template used in the SMS to send to the user. Use __CODE__ to insert the SMS code and __URL__ for the authentication url, or __URL2__ to insert a link that includes the code",
         "smsdef": "This is your vote code: __CODE__",
         "email": "Email message",
+        "htmlemail": "HTML Email message",
         "emailsub": "Email subject",
         "emailtemp": "Template used in the Email link to send to the user. Use __CODE__ to insert the login code and __URL__ to insert the election link, or _URL2__ to insert a link that includes the code",
+        "htmlemailtemp": "HTML Template used in the Email link to send to the user. Use __CODE__ to insert the login code and __URL__ to insert the election link, or _URL2__ to insert a link that includes the code",
         "emailsubdef": "Vote now with __name__",
         "emaildef": "Vote in __URL__ with code __CODE__",
         "slugKeys": "Use the following keys to insert the users' extra fields into the message: __slug_list__"

--- a/locales/es.json
+++ b/locales/es.json
@@ -711,8 +711,10 @@
         "smstemp": "Plantilla usada en el SMS a enviar al usuario. Usa __CODE__ para insertar el código SMS y __URL__ para insertar el enlace de votación, o __URL2__ para insertar un enlace que incluya el código",
         "smsdef": "Este es tu código de votación __CODE__",
         "email": "Cuerpo del mensaje",
+        "htmlemail": "Cuerpo HTML del mensaje",
         "emailsub": "Asunto del email",
         "emailtemp": "Plantilla usada en el correo para enviar a los usuarios. Usa __CODE__ para añadir el código de acceso y __URL__ para insertar el enlace de votación, o __URL2__ para insertar un enlace que incluya el código",
+        "htmlemailtemp": "Plantilla HTML usada en el correo para enviar a los usuarios. Usa __CODE__ para añadir el código de acceso y __URL__ para insertar el enlace de votación, o __URL2__ para insertar un enlace que incluya el código",
         "emailsubdef": "Ya puedes votar con __name__",
         "emaildef": "Vota en __URL__ con el codigo __CODE__",
         "slugKeys": "Usa las siguientes claves para insertar en el mensaje los campos extra de usuario: __slug_list__"


### PR DESCRIPTION
# Changes
 * Allow to configure both plain-text and HTML email body when sending email codes both from the dashboard and in the census tab to specific voters, and configure it to actually integrate with the IAM backend properly.
 * Allow to configure both plain-text and HTML email body when creating the election.  
 * Show a preview of the html message before sending it.