### PR TITLE
Support sending reminders to voters who didn't cast a vote

### DIFF
--- a/avAdmin/admin-directives/dashboard/dashboard.less
+++ b/avAdmin/admin-directives/dashboard/dashboard.less
@@ -227,12 +227,11 @@
     .checkbox.text-right {
       margin-top: -10px;
       margin-bottom: 20px;
+      padding: 5px;
 
       label {
         span, input {
           float: right;
-          margin: 0;
-          padding: 5px;
         }
 
         input {

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
@@ -97,6 +97,7 @@
         </div>
       </div>
     </div>
+    <div class="clearfix" ng-if="allowHtmlEmails"></div>
     <div class="form-group" ng-if="allowHtmlEmails">
       <label
         class="col-xs-3 control-label text-right padding-top-sm"
@@ -114,6 +115,7 @@
 
   <!-- filter config -->
   <div ng-if="showFilter" class="preview">
+    <div class="clearfix"></div>
     <div class="form-group" >
       <label
         class="col-xs-3 control-label text-right padding-top-sm"

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
@@ -110,7 +110,11 @@
         </div>
       </div>
     </div>
-    <div class="form-group" ng-if="showFilter()">
+  </div>
+
+  <!-- filter config -->
+  <div ng-if="showFilter" class="preview">
+    <div class="form-group" >
       <label
         class="col-xs-3 control-label text-right padding-top-sm"
         ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterTitle">
@@ -124,6 +128,7 @@
       </div>
     </div>
   </div>
+
   <div class="clearfix"></div>
 </div>
 

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
@@ -110,6 +110,19 @@
         </div>
       </div>
     </div>
+    <div class="form-group" ng-if="showFilter()">
+      <label
+        class="col-xs-3 control-label text-right padding-top-sm"
+        ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterTitle">
+      </label>
+      <div class="col-xs-9">
+        <div
+          ng-click="editAuthCodes()"
+          class="preview-data preview-body"
+          ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterOptions.{{ filterLabel }}">
+        </div>
+      </div>
+    </div>
   </div>
   <div class="clearfix"></div>
 </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
@@ -34,6 +34,19 @@ angular.module('avAdmin')
       selected_auth_method,
       exhtml)
     {
+      function calculateNumberOfRecipients() {
+        if (!!SendMsg.user_ids) {
+          return SendMsg.user_ids.length;
+        } else {
+          if ('voted' === SendMsg.filter) {
+            return $scope.election.votes;
+          } else if ('not_voted' === SendMsg.filter) {
+            return $scope.election.auth.census - $scope.election.votes;
+          } else {
+            return $scope.election.auth.census;
+          }
+        }
+      };
       $scope.election = election;
       $scope.selected_auth_method = selected_auth_method;
       $scope.user_ids = user_ids;
@@ -41,7 +54,7 @@ angular.module('avAdmin')
       $scope.steps = SendMsg.steps;
       $scope.censusConfig = SendMsg.censusConfig;
       $scope.loading = false;
-      $scope.numVoters = (!!SendMsg.user_ids) ? SendMsg.user_ids.length : $scope.election.auth.census;
+      $scope.numVoters = calculateNumberOfRecipients();
       $scope.helpurl = ConfigService.helpUrl;
       $scope.allowHtmlEmails = ConfigService.allowHtmlEmails;
       $scope.showFilter = !user_ids;

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
@@ -44,9 +44,7 @@ angular.module('avAdmin')
       $scope.numVoters = (!!SendMsg.user_ids) ? SendMsg.user_ids.length : $scope.election.auth.census;
       $scope.helpurl = ConfigService.helpUrl;
       $scope.allowHtmlEmails = ConfigService.allowHtmlEmails;
-      $scope.showFilter = function () {
-        return !user_ids && $scope.selected_auth_method === 'email';
-      };
+      $scope.showFilter = !user_ids;
       $scope.filterLabel = SendMsg.filter || 'none';
 
       $scope = _.extend($scope, exhtml.scope);

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
@@ -46,7 +46,7 @@ angular.module('avAdmin')
             return $scope.election.auth.census;
           }
         }
-      };
+      }
       $scope.election = election;
       $scope.selected_auth_method = selected_auth_method;
       $scope.user_ids = user_ids;

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
@@ -44,6 +44,10 @@ angular.module('avAdmin')
       $scope.numVoters = (!!SendMsg.user_ids) ? SendMsg.user_ids.length : $scope.election.auth.census;
       $scope.helpurl = ConfigService.helpUrl;
       $scope.allowHtmlEmails = ConfigService.allowHtmlEmails;
+      $scope.showFilter = function () {
+        return !user_ids && $scope.selected_auth_method === 'email';
+      };
+      $scope.filterLabel = SendMsg.filter || 'none';
 
       $scope = _.extend($scope, exhtml.scope);
       $scope.exhtml = exhtml.html;

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -130,25 +130,30 @@
                   >
                   </textarea>
               </div>
-              <label
-                class="col-xs-3 control-label text-right padding-top-input"
-                ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterTitle"
-                ng-if="showFilter()">
-              </label>
-              <div class="col-xs-9" ng-if="showFilter()">
-                <p class="text-muted" ng-i18next>avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterDescription</p>
-                <div class="radio" ng-repeat="filterOption in filterOptions">
-                    <label>
-                        <input
-                          type="radio"
-                          name="filter-option-{{ filterOption.label }}"
-                          value="{{ filterOption.value }}"
-                          ng-model="filter.ref"/>
-                        <span ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterOptions.{{ filterOption.label }}"></span>
-                    </label>
-                </div>
-              </div>
           </div>
+      </div>
+      <!-- Filter conf-->
+      <div ng-if="showFilter">
+        <div class="clearfix"></div>
+        <div class="form-group">
+          <label
+            class="col-xs-3 control-label text-right padding-top-input"
+            ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterTitle">
+          </label>
+          <div class="col-xs-9">
+            <p class="text-muted" ng-i18next>avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterDescription</p>
+            <div class="radio" ng-repeat="filterOption in filterOptions">
+                <label>
+                    <input
+                      type="radio"
+                      name="filter-option-{{ filterOption.label }}"
+                      value="{{ filterOption.value }}"
+                      ng-model="filter.ref"/>
+                    <span ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterOptions.{{ filterOption.label }}"></span>
+                </label>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -93,11 +93,11 @@
           <div class="form-group">
               <label
                 class="col-xs-3 control-label text-right padding-top-input"
-                ng-i18next="avAdmin.modals.sendAuthCodes.filterTitle"
+                ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.filterTitle"
                 ng-if="showFilter()">
               </label>
               <div class="col-xs-9" ng-if="showFilter()">
-                <p class="text-muted" ng-i18next> avAdmin.modals.sendAuthCodes.filterDescription</p>
+                <p class="text-muted" ng-i18next>avAdmin.dashboard.modals.sendAuthCodes.filterDescription</p>
                 <div class="radio" ng-repeat="filterOption in filterOptions">
                     <label>
                         <input
@@ -105,7 +105,7 @@
                           name="voting"
                           value="{{ filterOption.value }}"
                           ng-model="filter"/>
-                        <span ng-i18next="avCommon.modals.sendAuthCodes.filterOptions.{{ filterOption.label }}"></span>
+                        <span ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.filterOptions.{{ filterOption.label }}"></span>
                     </label>
                 </div>
               </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -102,9 +102,9 @@
                     <label>
                         <input
                           type="radio"
-                          name="voting"
+                          name="filter-option-{{ filterOption.label }}"
                           value="{{ filterOption.value }}"
-                          ng-model="filter"/>
+                          ng-model="filter.ref"/>
                         <span ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterOptions.{{ filterOption.label }}"></span>
                     </label>
                 </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -93,24 +93,6 @@
           <div class="form-group">
               <label
                 class="col-xs-3 control-label text-right padding-top-input"
-                ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterTitle"
-                ng-if="showFilter()">
-              </label>
-              <div class="col-xs-9" ng-if="showFilter()">
-                <p class="text-muted" ng-i18next>avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterDescription</p>
-                <div class="radio" ng-repeat="filterOption in filterOptions">
-                    <label>
-                        <input
-                          type="radio"
-                          name="filter-option-{{ filterOption.label }}"
-                          value="{{ filterOption.value }}"
-                          ng-model="filter.ref"/>
-                        <span ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterOptions.{{ filterOption.label }}"></span>
-                    </label>
-                </div>
-              </div>
-              <label
-                class="col-xs-3 control-label text-right padding-top-input"
                 ng-i18next="avAdmin.auth.email">
               </label>
               <div class="col-xs-9">
@@ -147,6 +129,24 @@
                     ng-model="censusConfig.html_message"
                   >
                   </textarea>
+              </div>
+              <label
+                class="col-xs-3 control-label text-right padding-top-input"
+                ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterTitle"
+                ng-if="showFilter()">
+              </label>
+              <div class="col-xs-9" ng-if="showFilter()">
+                <p class="text-muted" ng-i18next>avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterDescription</p>
+                <div class="radio" ng-repeat="filterOption in filterOptions">
+                    <label>
+                        <input
+                          type="radio"
+                          name="filter-option-{{ filterOption.label }}"
+                          value="{{ filterOption.value }}"
+                          ng-model="filter.ref"/>
+                        <span ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterOptions.{{ filterOption.label }}"></span>
+                    </label>
+                </div>
               </div>
           </div>
       </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -93,11 +93,11 @@
           <div class="form-group">
               <label
                 class="col-xs-3 control-label text-right padding-top-input"
-                ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.filterTitle"
+                ng-i18next="avAdmin.dashboard.modals.sendAuthCodesModal.filterTitle"
                 ng-if="showFilter()">
               </label>
               <div class="col-xs-9" ng-if="showFilter()">
-                <p class="text-muted" ng-i18next>avAdmin.dashboard.modals.sendAuthCodes.filterDescription</p>
+                <p class="text-muted" ng-i18next>avAdmin.dashboard.modals.sendAuthCodesModal.filterDescription</p>
                 <div class="radio" ng-repeat="filterOption in filterOptions">
                     <label>
                         <input
@@ -105,7 +105,7 @@
                           name="voting"
                           value="{{ filterOption.value }}"
                           ng-model="filter"/>
-                        <span ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.filterOptions.{{ filterOption.label }}"></span>
+                        <span ng-i18next="avAdmin.dashboard.modals.sendAuthCodesModal.filterOptions.{{ filterOption.label }}"></span>
                     </label>
                 </div>
               </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -93,6 +93,24 @@
           <div class="form-group">
               <label
                 class="col-xs-3 control-label text-right padding-top-input"
+                ng-i18next="avAdmin.modals.sendAuthCodes.filterTitle"
+                ng-if="showFilter()">
+              </label>
+              <div class="col-xs-9" ng-if="showFilter()">
+                <p class="text-muted" ng-i18next> avAdmin.modals.sendAuthCodes.filterDescription</p>
+                <div class="radio" ng-repeat="filterOption in filterOptions">
+                    <label>
+                        <input
+                          type="radio"
+                          name="voting"
+                          value="{{ filterOption.value }}"
+                          ng-model="filter"/>
+                        <span ng-i18next="avCommon.modals.sendAuthCodes.filterOptions.{{ filterOption.label }}"></span>
+                    </label>
+                </div>
+              </div>
+              <label
+                class="col-xs-3 control-label text-right padding-top-input"
                 ng-i18next="avAdmin.auth.email">
               </label>
               <div class="col-xs-9">

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -93,11 +93,11 @@
           <div class="form-group">
               <label
                 class="col-xs-3 control-label text-right padding-top-input"
-                ng-i18next="avAdmin.dashboard.modals.sendAuthCodesModal.filterTitle"
+                ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterTitle"
                 ng-if="showFilter()">
               </label>
               <div class="col-xs-9" ng-if="showFilter()">
-                <p class="text-muted" ng-i18next>avAdmin.dashboard.modals.sendAuthCodesModal.filterDescription</p>
+                <p class="text-muted" ng-i18next>avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterDescription</p>
                 <div class="radio" ng-repeat="filterOption in filterOptions">
                     <label>
                         <input
@@ -105,7 +105,7 @@
                           name="voting"
                           value="{{ filterOption.value }}"
                           ng-model="filter"/>
-                        <span ng-i18next="avAdmin.dashboard.modals.sendAuthCodesModal.filterOptions.{{ filterOption.label }}"></span>
+                        <span ng-i18next="avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.filterOptions.{{ filterOption.label }}"></span>
                     </label>
                 </div>
               </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
@@ -36,6 +36,24 @@ angular
       $scope.censusConfig = SendMsg.censusConfig;
       $scope.helpurl = ConfigService.helpUrl;
       $scope.allowHtmlEmails = ConfigService.allowHtmlEmails;
+      $scope.showFilter = function () {
+        return !user_ids && $scope.selected_auth_method.ref === 'email';
+      };
+      $scope.filterOptions = [
+        {
+          label: 'none',
+          value: null,
+        },
+        {
+          label: 'voted',
+          value: 'voted',
+        },
+        {
+          label: 'not_voted',
+          value: 'not_voted',
+        },
+      ];
+      $scope.filter = null;
       var slug_text = "";
       for (var i = 0; i < SendMsg.slug_list.length; i++) {
         slug_text += (0 !== i? ", " : "" ) + "__" + SendMsg.slug_list[i] + "__";
@@ -43,6 +61,7 @@ angular
       $scope.slug_text = slug_text;
       $scope.ok = function () {
         SendMsg.selected_auth_method = $scope.selected_auth_method.ref;
+        SendMsg.filter = showFilter? $scope.filter : undefined;
         $modalInstance.close($scope.user_ids);
       };
 

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
@@ -53,7 +53,7 @@ angular
           value: 'not_voted',
         },
       ];
-      $scope.filter = null;
+      $scope.filter = { ref: null };
       var slug_text = "";
       for (var i = 0; i < SendMsg.slug_list.length; i++) {
         slug_text += (0 !== i? ", " : "" ) + "__" + SendMsg.slug_list[i] + "__";
@@ -61,7 +61,7 @@ angular
       $scope.slug_text = slug_text;
       $scope.ok = function () {
         SendMsg.selected_auth_method = $scope.selected_auth_method.ref;
-        SendMsg.filter = $scope.showFilter()? $scope.filter : undefined;
+        SendMsg.filter = $scope.showFilter()? $scope.filter.ref : undefined;
         $modalInstance.close($scope.user_ids);
       };
 

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
@@ -36,9 +36,7 @@ angular
       $scope.censusConfig = SendMsg.censusConfig;
       $scope.helpurl = ConfigService.helpUrl;
       $scope.allowHtmlEmails = ConfigService.allowHtmlEmails;
-      $scope.showFilter = function () {
-        return !user_ids && $scope.selected_auth_method.ref === 'email';
-      };
+      $scope.showFilter = !user_ids;
       $scope.filterOptions = [
         {
           label: 'none',
@@ -61,7 +59,7 @@ angular
       $scope.slug_text = slug_text;
       $scope.ok = function () {
         SendMsg.selected_auth_method = $scope.selected_auth_method.ref;
-        SendMsg.filter = $scope.showFilter()? ($scope.filter.ref || null) : undefined;
+        SendMsg.filter = $scope.showFilter? ($scope.filter.ref || null) : undefined;
         $modalInstance.close($scope.user_ids);
       };
 

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
@@ -42,7 +42,7 @@ angular
       $scope.filterOptions = [
         {
           label: 'none',
-          value: null,
+          value: '',
         },
         {
           label: 'voted',
@@ -53,7 +53,7 @@ angular
           value: 'not_voted',
         },
       ];
-      $scope.filter = { ref: null };
+      $scope.filter = { ref: '' };
       var slug_text = "";
       for (var i = 0; i < SendMsg.slug_list.length; i++) {
         slug_text += (0 !== i? ", " : "" ) + "__" + SendMsg.slug_list[i] + "__";
@@ -61,7 +61,7 @@ angular
       $scope.slug_text = slug_text;
       $scope.ok = function () {
         SendMsg.selected_auth_method = $scope.selected_auth_method.ref;
-        SendMsg.filter = $scope.showFilter()? $scope.filter.ref : undefined;
+        SendMsg.filter = $scope.showFilter()? ($scope.filter.ref || null) : undefined;
         $modalInstance.close($scope.user_ids);
       };
 

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
@@ -61,7 +61,7 @@ angular
       $scope.slug_text = slug_text;
       $scope.ok = function () {
         SendMsg.selected_auth_method = $scope.selected_auth_method.ref;
-        SendMsg.filter = showFilter? $scope.filter : undefined;
+        SendMsg.filter = $scope.showFilter()? $scope.filter : undefined;
         $modalInstance.close($scope.user_ids);
       };
 

--- a/avAdmin/send-messages-service.js
+++ b/avAdmin/send-messages-service.js
@@ -269,7 +269,8 @@ angular
             electionCopy,
             service.user_ids,
             service.selected_auth_method,
-            service.extra
+            service.extra,
+            service.filter
           ).then(
             function onSuccess(response)
             {

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -138,6 +138,15 @@
           "header": "Ver acta electoral",
           "edit": "Editar y cambiar acta electoral",
           "tallySheetIdLabel": "Id de acta electoral:"
+        },
+        "sendAuthCodes": {
+          "filterTitle": "Filtrar",
+          "filterDescription": "Envieu aquest correu electrònic a part del cens, ja sigui als que ja van votar o als que encara no van votar.",
+          "filterOptions": {
+            "none": "Enviar a tots",
+            "voted": "Enviar als que han votat",
+            "not_voted": "Enviar als que encara no han votat"
+          }
         }
       },
       "viewTallySheetAction": "Ver acta electoral",

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -390,7 +390,14 @@
               "header": "Enviar códigos de autenticación (Paso __step__ de __total__)",
               "helpInfo": "Esta votación enviará un mensaje a todos los electores registrados en el censo. Nótese que enviar muchos mensajes puede considerarse SPAM, así que procede con precaución. Además, por favor comprueba primero el texto del mensaje que vas a enviar.",
               "sendButton": "Revisar mensaje antes de enviar códigos de autenticación a TODO el censo",
-              "sendSelectedButton": "Revisar mensaje antes de enviar códigos de autenticación a los usuarios SELECCIONADOS"
+              "sendSelectedButton": "Revisar mensaje antes de enviar códigos de autenticación a los usuarios SELECCIONADOS",
+              "filterTitle": "Filtrar",
+              "filterDescription": "Envieu aquest correu electrònic a part del cens, ja sigui als que ja van votar o als que encara no van votar.",
+              "filterOptions": {
+                "none": "Enviar a tots",
+                "voted": "Enviar als que han votat",
+                "not_voted": "Enviar als que encara no han votat"
+              }
             },
             "confirmStep": {
               "header": "Enviar códigos de autenticación (Paso __step__ de __total__)",
@@ -412,15 +419,6 @@
             "header": "Resetear votante al estado de pre-registro",
             "body": "Resetear votante al estado de pre-registro. Esto implica que cualquier campo que fuera rellenado por el votante durante su registro será borrado/reseteado, pero los datos del votante que eran parte del censo de pre-registro no serán alterados. Puede añadir debajo un comentario explicando porqué ejecuta esta acción sobre este votante:",
             "confirmButton": "RESETEAR VOTANTE al estado de pre-registro"
-          },
-          "sendAuthCodesModal": {
-            "filterTitle": "Filtrar",
-            "filterDescription": "Envieu aquest correu electrònic a part del cens, ja sigui als que ja van votar o als que encara no van votar.",
-            "filterOptions": {
-              "none": "Enviar a tots",
-              "voted": "Enviar als que han votat",
-              "not_voted": "Enviar als que encara no han votat"
-            }
           }
         }
     },

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -138,15 +138,6 @@
           "header": "Ver acta electoral",
           "edit": "Editar y cambiar acta electoral",
           "tallySheetIdLabel": "Id de acta electoral:"
-        },
-        "sendAuthCodes": {
-          "filterTitle": "Filtrar",
-          "filterDescription": "Envieu aquest correu electrònic a part del cens, ja sigui als que ja van votar o als que encara no van votar.",
-          "filterOptions": {
-            "none": "Enviar a tots",
-            "voted": "Enviar als que han votat",
-            "not_voted": "Enviar als que encara no han votat"
-          }
         }
       },
       "viewTallySheetAction": "Ver acta electoral",
@@ -421,6 +412,15 @@
             "header": "Resetear votante al estado de pre-registro",
             "body": "Resetear votante al estado de pre-registro. Esto implica que cualquier campo que fuera rellenado por el votante durante su registro será borrado/reseteado, pero los datos del votante que eran parte del censo de pre-registro no serán alterados. Puede añadir debajo un comentario explicando porqué ejecuta esta acción sobre este votante:",
             "confirmButton": "RESETEAR VOTANTE al estado de pre-registro"
+          },
+          "sendAuthCodes": {
+            "filterTitle": "Filtrar",
+            "filterDescription": "Envieu aquest correu electrònic a part del cens, ja sigui als que ja van votar o als que encara no van votar.",
+            "filterOptions": {
+              "none": "Enviar a tots",
+              "voted": "Enviar als que han votat",
+              "not_voted": "Enviar als que encara no han votat"
+            }
           }
         }
     },

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -413,7 +413,7 @@
             "body": "Resetear votante al estado de pre-registro. Esto implica que cualquier campo que fuera rellenado por el votante durante su registro será borrado/reseteado, pero los datos del votante que eran parte del censo de pre-registro no serán alterados. Puede añadir debajo un comentario explicando porqué ejecuta esta acción sobre este votante:",
             "confirmButton": "RESETEAR VOTANTE al estado de pre-registro"
           },
-          "sendAuthCodes": {
+          "sendAuthCodesModal": {
             "filterTitle": "Filtrar",
             "filterDescription": "Envieu aquest correu electrònic a part del cens, ja sigui als que ja van votar o als que encara no van votar.",
             "filterOptions": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -443,7 +443,7 @@
             "body": "This dialog allows you to edit the calculate results json. Use this only if you know what you are doing.",
             "confirmEdit": "Finish edit"
           },
-          "sendAuthCodes": {
+          "sendAuthCodesModal": {
             "editMessageStep": {
               "header": "Send authentication codes (Step __step__ of __total__)",
               "helpInfo": "This action will send a message to all the registered electors in the census. Note that sending many messages can be considered as SPAM, so proceed with caution. Also, please review the message that will be sent before proceeding.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -443,12 +443,19 @@
             "body": "This dialog allows you to edit the calculate results json. Use this only if you know what you are doing.",
             "confirmEdit": "Finish edit"
           },
-          "sendAuthCodesModal": {
+          "sendAuthCodes": {
             "editMessageStep": {
               "header": "Send authentication codes (Step __step__ of __total__)",
               "helpInfo": "This action will send a message to all the registered electors in the census. Note that sending many messages can be considered as SPAM, so proceed with caution. Also, please review the message that will be sent before proceeding.",
               "sendButton": "Review message before sending authentication codes to ALL census",
-              "sendSelectedButton": "Review message before sending authentication codes to SELECTED users"
+              "sendSelectedButton": "Review message before sending authentication codes to SELECTED users",
+              "filterTitle": "Filter",
+              "filterDescription": "Send this email to part of the census, either those that have already voted or those that haven't voted yet.",
+              "filterOptions": {
+                "none": "Sent to everyone",
+                "voted": "Send to those that have voted",
+                "not_voted": "Send to those that haven't voted yet"
+              }
             },
             "confirmStep": {
               "header": "Send authentication codes (Step __step__ of __total__)",
@@ -524,15 +531,6 @@
             "body": "Resuming the election when it has previously been suspend temporarily will allow again voters casting a vote.",
             "confirmButton": "RESUME the election voting period",
             "success": "Election voting period resumed successfully."
-          },
-          "sendAuthCodes": {
-            "filterTitle": "Filter",
-            "filterDescription": "Send this email to part of the census, either those that have already voted or those that haven't voted yet.",
-            "filterOptions": {
-              "none": "Sent to everyone",
-              "voted": "Send to those that have voted",
-              "not_voted": "Send to those that haven't voted yet"
-            }
           }
         }
     },

--- a/locales/en.json
+++ b/locales/en.json
@@ -140,6 +140,15 @@
             "header": "View tally sheet",
             "edit": "Edit and change tally sheet",
             "tallySheetIdLabel": "Tally sheet id:"
+          },
+          "sendAuthCodes": {
+            "filterTitle": "Filter",
+            "filterDescription": "Send this email to part of the census, either those that have already voted or those that haven't voted yet.",
+            "filterOptions": {
+              "none": "Sent to everyone",
+              "voted": "Send to those that have voted",
+              "not_voted": "Send to those that haven't voted yet"
+            }
           }
       },
       "viewTallySheetAction": "View tally sheet",

--- a/locales/en.json
+++ b/locales/en.json
@@ -140,15 +140,6 @@
             "header": "View tally sheet",
             "edit": "Edit and change tally sheet",
             "tallySheetIdLabel": "Tally sheet id:"
-          },
-          "sendAuthCodes": {
-            "filterTitle": "Filter",
-            "filterDescription": "Send this email to part of the census, either those that have already voted or those that haven't voted yet.",
-            "filterOptions": {
-              "none": "Sent to everyone",
-              "voted": "Send to those that have voted",
-              "not_voted": "Send to those that haven't voted yet"
-            }
           }
       },
       "viewTallySheetAction": "View tally sheet",
@@ -533,6 +524,15 @@
             "body": "Resuming the election when it has previously been suspend temporarily will allow again voters casting a vote.",
             "confirmButton": "RESUME the election voting period",
             "success": "Election voting period resumed successfully."
+          },
+          "sendAuthCodes": {
+            "filterTitle": "Filter",
+            "filterDescription": "Send this email to part of the census, either those that have already voted or those that haven't voted yet.",
+            "filterOptions": {
+              "none": "Sent to everyone",
+              "voted": "Send to those that have voted",
+              "not_voted": "Send to those that haven't voted yet"
+            }
           }
         }
     },

--- a/locales/es.json
+++ b/locales/es.json
@@ -138,6 +138,15 @@
             "header": "Ver acta electoral",
             "edit": "Editar y cambiar acta electoral",
             "tallySheetIdLabel": "Id de acta electoral:"
+          },
+          "sendAuthCodes": {
+            "filterTitle": "Filtrar",
+            "filterDescription": "Envíe este correo electrónico a parte del censo, ya sea a los que ya votaron o a los que aún no votaron.",
+            "filterOptions": {
+              "none": "Enviar a todos",
+              "voted": "Enviar a los que han votado",
+              "not_voted": "Enviar a los que todavía no han votado"
+            }
           }
       },
       "viewTallySheetAction": "Ver acta electoral",

--- a/locales/es.json
+++ b/locales/es.json
@@ -489,7 +489,7 @@
             "body": "Resetear votante al estado de pre-registro. Esto implica que cualquier campo que fuera rellenado por el votante durante su registro será borrado/reseteado, pero los datos del votante que eran parte del censo de pre-registro no serán alterados. Puede añadir debajo un comentario explicando porqué ejecuta esta acción sobre este votante:",
             "confirmButton": "RESETEAR VOTANTE al estado de pre-registro"
           },
-          "sendAuthCodes": {
+          "sendAuthCodesModal": {
             "filterTitle": "Filtrar",
             "filterDescription": "Envíe este correo electrónico a parte del censo, ya sea a los que ya votaron o a los que aún no votaron.",
             "filterOptions": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -138,15 +138,6 @@
             "header": "Ver acta electoral",
             "edit": "Editar y cambiar acta electoral",
             "tallySheetIdLabel": "Id de acta electoral:"
-          },
-          "sendAuthCodes": {
-            "filterTitle": "Filtrar",
-            "filterDescription": "Envíe este correo electrónico a parte del censo, ya sea a los que ya votaron o a los que aún no votaron.",
-            "filterOptions": {
-              "none": "Enviar a todos",
-              "voted": "Enviar a los que han votado",
-              "not_voted": "Enviar a los que todavía no han votado"
-            }
           }
       },
       "viewTallySheetAction": "Ver acta electoral",
@@ -497,6 +488,15 @@
             "header": "Resetear votante al estado de pre-registro",
             "body": "Resetear votante al estado de pre-registro. Esto implica que cualquier campo que fuera rellenado por el votante durante su registro será borrado/reseteado, pero los datos del votante que eran parte del censo de pre-registro no serán alterados. Puede añadir debajo un comentario explicando porqué ejecuta esta acción sobre este votante:",
             "confirmButton": "RESETEAR VOTANTE al estado de pre-registro"
+          },
+          "sendAuthCodes": {
+            "filterTitle": "Filtrar",
+            "filterDescription": "Envíe este correo electrónico a parte del censo, ya sea a los que ya votaron o a los que aún no votaron.",
+            "filterOptions": {
+              "none": "Enviar a todos",
+              "voted": "Enviar a los que han votado",
+              "not_voted": "Enviar a los que todavía no han votado"
+            }
           }
         }
     },

--- a/locales/es.json
+++ b/locales/es.json
@@ -424,7 +424,14 @@
               "header": "Enviar códigos de autenticación (Paso __step__ de __total__)",
               "helpInfo": "Esta votación enviará un mensaje a todos los electores registrados en el censo. Nótese que enviar muchos mensajes puede considerarse SPAM, así que procede con precaución. Además, por favor comprueba primero el texto del mensaje que vas a enviar.",
               "sendButton": "Revisar mensaje antes de enviar códigos de autenticación a TODO el censo",
-              "sendSelectedButton": "Revisar mensaje antes de enviar códigos de autenticación a los usuarios SELECCIONADOS"
+              "sendSelectedButton": "Revisar mensaje antes de enviar códigos de autenticación a los usuarios SELECCIONADOS",
+              "filterTitle": "Filtrar",
+              "filterDescription": "Envíe este correo electrónico a parte del censo, ya sea a los que ya votaron o a los que aún no votaron.",
+              "filterOptions": {
+                "none": "Enviar a todos",
+                "voted": "Enviar a los que han votado",
+                "not_voted": "Enviar a los que todavía no han votado"
+              }
             },
             "confirmStep": {
               "header": "Enviar códigos de autenticación (Paso __step__ de __total__)",
@@ -488,15 +495,6 @@
             "header": "Resetear votante al estado de pre-registro",
             "body": "Resetear votante al estado de pre-registro. Esto implica que cualquier campo que fuera rellenado por el votante durante su registro será borrado/reseteado, pero los datos del votante que eran parte del censo de pre-registro no serán alterados. Puede añadir debajo un comentario explicando porqué ejecuta esta acción sobre este votante:",
             "confirmButton": "RESETEAR VOTANTE al estado de pre-registro"
-          },
-          "sendAuthCodesModal": {
-            "filterTitle": "Filtrar",
-            "filterDescription": "Envíe este correo electrónico a parte del censo, ya sea a los que ya votaron o a los que aún no votaron.",
-            "filterOptions": {
-              "none": "Enviar a todos",
-              "voted": "Enviar a los que han votado",
-              "not_voted": "Enviar a los que todavía no han votado"
-            }
           }
         }
     },


### PR DESCRIPTION
Enable sending emails/sms messages to part of the census, filtering by whether the voters have already casted their vote or not.

# Changes
* Add an option to send messages to part of the census: either those that have voted or those that haven't voted yet.
* Show that option in the modal, only when sending to the whole census and not for individual users.
* Add translations.

# Screenshots

Election with email authentication:

<img width="710" alt="Screenshot 2022-09-05 at 14 37 30" src="https://user-images.githubusercontent.com/3913223/188505929-45e5a570-46e2-4c5c-bb0d-5945a4e140ce.png">
<img width="745" alt="Screenshot 2022-09-05 at 14 38 18" src="https://user-images.githubusercontent.com/3913223/188505992-8920a8b0-f0be-4ae8-ab9d-505958872d47.png">


Election with SMS authentication:

<img width="810" alt="Screenshot 2022-09-05 at 14 36 22" src="https://user-images.githubusercontent.com/3913223/188505844-627de85d-630c-4cef-84ff-697077a3a9e4.png">
<img width="681" alt="Screenshot 2022-09-05 at 14 36 31" src="https://user-images.githubusercontent.com/3913223/188505857-60f38476-a243-4d48-88d2-22e838c35e6c.png">

