### PR TITLE
Election IDs automation

### DIFF
--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -1277,7 +1277,7 @@ angular.module('avAdmin')
             return _.isNumber(el.id) && el.id <= 0;
           });
 
-          if (data.length > 1 || hasNegativeIds) {
+          if (elections.length > 1 || hasNegativeIds) {
 
             // Find highest election id
             Authmethod.highestEvent()
@@ -1287,18 +1287,18 @@ angular.module('avAdmin')
                     var newIdsMap = {};
 
                     // map negative ids to new election ids
-                    for (var eid = 0; eid < elections.length; eid++) {
-                      var election = elections[eid];
-                      if (_.isNumber(election.id) && election.id > 0) {
-                        newIdsMap[election.id] = election.id;
+                    for (var idx = 0; idx < elections.length; idx++) {
+                      var electionId = elections[idx].id;
+                      if (_.isNumber(electionId) && electionId > 0) {
+                        newIdsMap[electionId] = electionId;
                       } else {
-                        newIdsMap[election.id] = highestId + eid + 1;
+                        newIdsMap[electionId] = highestId + idx + 1;
                       }
                     }
 
                     // replace election ids with new ids
-                    for (var eid = 0; eid < elections.length; eid++) {
-                      var election = elections[eid];
+                    for (var index = 0; index < elections.length; index++) {
+                      var election = elections[index];
                       // replace the election id
                       election.id = newIdsMap[election.id];
 

--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -1333,6 +1333,7 @@ angular.module('avAdmin')
                                 if (event.event_id) {
                                   event.event_id = newIdsMap[event.event_id] || event.event_id;
                                 }
+                                return event;
                               });
                             }
                             return category;

--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -1263,76 +1263,6 @@ angular.module('avAdmin')
           deferred.resolve(scope.elections[electionIndex]);
         }
 
-        function addElection(electionIndex) 
-        {
-          var deferred = $q.defer();
-
-          // After creating the auth events and registering all the elections 
-          // in ballot_box, we proceed to:
-          // - set children election info
-          // - add census
-          // - create election public keys
-          if (electionIndex === scope.elections.length) {
-            secondElectionsStage(0);
-            return;
-          }
-
-          var promise = deferred.promise;
-          promise = promise
-            .then(createAuthEvent)
-            .then(registerElection)
-            .then(function(election) {
-              addElection(electionIndex + 1);
-            })
-            .catch(function(error) {
-              scope.creating = false;
-              scope.creating_text = '';
-              logError(angular.toJson(error));
-            });
-          deferred.resolve(scope.elections[electionIndex]);
-        }
-
-        scope.editJson = function()
-        {
-          if(!ConfigService.allowEditElectionJson) {
-            return;
-          }
-          // show the initial edit dialog
-          $modal
-            .open({
-              templateUrl: "avAdmin/admin-directives/create/edit-election-json-modal.html",
-              controller: "EditElectionJsonModal",
-              size: 'lg',
-              resolve: {
-                electionJson: function () { return angular.toJson(scope.elections, true); }
-              }
-            })
-            .result.then(
-              function (data)
-              {
-                var elections = angular.fromJson(data.electionJson);
-                return fillInElectionIds(elections);
-              }
-            ).then(
-              function (data)
-              {
-                scope.elections = data;
-
-                scope.errors = [];
-                CheckerService({
-                  checks: checks,
-                  data: scope.elections,
-                  onError: function (errorKey, errorData) {
-                    scope.errors.push({
-                      data: $sanitize(errorData),
-                      key: errorKey
-                    });
-                  }
-                });
-              }
-            );
-        };
-
         /**
          * If the elections are using negative numbers, find the existing election
          * with the highest election id and replace the negative numbers with
@@ -1411,6 +1341,76 @@ angular.module('avAdmin')
           }
           return promise;
         }
+
+        function addElection(electionIndex) 
+        {
+          var deferred = $q.defer();
+
+          // After creating the auth events and registering all the elections 
+          // in ballot_box, we proceed to:
+          // - set children election info
+          // - add census
+          // - create election public keys
+          if (electionIndex === scope.elections.length) {
+            secondElectionsStage(0);
+            return;
+          }
+
+          var promise = deferred.promise;
+          promise = promise
+            .then(createAuthEvent)
+            .then(registerElection)
+            .then(function(election) {
+              addElection(electionIndex + 1);
+            })
+            .catch(function(error) {
+              scope.creating = false;
+              scope.creating_text = '';
+              logError(angular.toJson(error));
+            });
+          deferred.resolve(scope.elections[electionIndex]);
+        }
+
+        scope.editJson = function()
+        {
+          if(!ConfigService.allowEditElectionJson) {
+            return;
+          }
+          // show the initial edit dialog
+          $modal
+            .open({
+              templateUrl: "avAdmin/admin-directives/create/edit-election-json-modal.html",
+              controller: "EditElectionJsonModal",
+              size: 'lg',
+              resolve: {
+                electionJson: function () { return angular.toJson(scope.elections, true); }
+              }
+            })
+            .result.then(
+              function (data)
+              {
+                var elections = angular.fromJson(data.electionJson);
+                return fillInElectionIds(elections);
+              }
+            ).then(
+              function (data)
+              {
+                scope.elections = data;
+
+                scope.errors = [];
+                CheckerService({
+                  checks: checks,
+                  data: scope.elections,
+                  onError: function (errorKey, errorData) {
+                    scope.errors.push({
+                      data: $sanitize(errorData),
+                      key: errorKey
+                    });
+                  }
+                });
+              }
+            );
+        };
 
         function createElections() {
             var deferred = $q.defer();

--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -1277,6 +1277,8 @@ angular.module('avAdmin')
             return _.isNumber(el.id) && el.id <= 0;
           });
 
+          /* jshint ignore:start */
+
           if (elections.length > 1 || hasNegativeIds) {
 
             // Find highest election id
@@ -1312,9 +1314,9 @@ angular.module('avAdmin')
                       // replace ids in the children elections structure
                       if (election.children_election_info &&
                           election.children_election_info.natural_order) {
-                        election.children_election_info.natural_order = election.children_election_info.natural_order.map(function (myMap, e) {
-                          return myMap[e] || e;
-                        }).bind(null, newIdsMap);
+                        election.children_election_info.natural_order = election.children_election_info.natural_order.map(function (e) {
+                          return newIdsMap[e] || e;
+                        });
                       }
                       if (election.children_election_info &&
                         election.children_election_info.presentation &&
@@ -1322,11 +1324,11 @@ angular.module('avAdmin')
                           election.children_election_info.presentation.categories = 
                           election.children_election_info.presentation.categories.map(function (category) {
                             if (category.events) {
-                              category.events = category.events.map(function (myMap, event) {
+                              category.events = category.events.map(function (event) {
                                 if (event.event_id) {
-                                  event.event_id = myMap[event.event_id] || event.event_id;
+                                  event.event_id = newIdsMap[event.event_id] || event.event_id;
                                 }
-                              }).bind(null, newIdsMap);
+                              });
                             }
                             return category;
                           });
@@ -1339,6 +1341,7 @@ angular.module('avAdmin')
           } else {
             deferred.resolve(elections);
           }
+          /* jshint ignore:end */
           return promise;
         }
 

--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -1304,6 +1304,11 @@ angular.module('avAdmin')
                       // replace the election id
                       election.id = newIdsMap[election.id];
 
+                      // replace the parent id
+                      if (election.parent_id) {
+                        election.parent_id = newIdsMap[election.parent_id] || election.parent_id;
+                      }
+
                       // replace ids for virtualSubelections
                       if (election.virtualSubelections) {
                         election.virtualSubelections = election.virtualSubelections.map(function (e) {

--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -1296,10 +1296,6 @@ angular.module('avAdmin')
                       }
                     }
 
-                    function mapElectionId(e) {
-                      return newIdsMap[e] || e;
-                    }
-
                     // replace election ids with new ids
                     for (var index = 0; index < elections.length; index++) {
                       var election = elections[index];
@@ -1316,7 +1312,9 @@ angular.module('avAdmin')
                       // replace ids in the children elections structure
                       if (election.children_election_info &&
                           election.children_election_info.natural_order) {
-                        election.children_election_info.natural_order = election.children_election_info.natural_order.map(mapElectionId);
+                        election.children_election_info.natural_order = election.children_election_info.natural_order.map(function (myMap, e) {
+                          return myMap[e] || e;
+                        }).bind(null, newIdsMap);
                       }
                       if (election.children_election_info &&
                         election.children_election_info.presentation &&
@@ -1324,11 +1322,11 @@ angular.module('avAdmin')
                           election.children_election_info.presentation.categories = 
                           election.children_election_info.presentation.categories.map(function (category) {
                             if (category.events) {
-                              category.events = category.events.map(function (event) {
+                              category.events = category.events.map(function (myMap, event) {
                                 if (event.event_id) {
-                                  event.event_id = mapElectionId(event.event_id);
+                                  event.event_id = myMap[event.event_id] || event.event_id;
                                 }
-                              });
+                              }).bind(null, newIdsMap);
                             }
                             return category;
                           });

--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -1296,6 +1296,10 @@ angular.module('avAdmin')
                       }
                     }
 
+                    function mapElectionId(e) {
+                      return newIdsMap[e] || e;
+                    }
+
                     // replace election ids with new ids
                     for (var index = 0; index < elections.length; index++) {
                       var election = elections[index];
@@ -1312,9 +1316,7 @@ angular.module('avAdmin')
                       // replace ids in the children elections structure
                       if (election.children_election_info &&
                           election.children_election_info.natural_order) {
-                        election.children_election_info.natural_order = election.children_election_info.natural_order.map(function (e) {
-                          return newIdsMap[e] || e;
-                        });
+                        election.children_election_info.natural_order = election.children_election_info.natural_order.map(mapElectionId);
                       }
                       if (election.children_election_info &&
                         election.children_election_info.presentation &&
@@ -1324,7 +1326,7 @@ angular.module('avAdmin')
                             if (category.events) {
                               category.events = category.events.map(function (event) {
                                 if (event.event_id) {
-                                  event.event_id = newIdsMap[event.event_id] || event.event_id;
+                                  event.event_id = mapElectionId(event.event_id);
                                 }
                               });
                             }


### PR DESCRIPTION
Automate filling in election IDs. If the election ID in the Election JSON is negative, replace it with new Election IDs.

# Changes
* Add new method `fillInElectionIds`. The method detects wether there's any election ID with negative numbers, if there isn't any it returns the election json unmodified.
* If there is a negative election ID, make a call to the auth api (IAM) to find out the highest existing election ID. Use that to replace the negative election IDs with new election IDs.
* Call the new method `fillInElectionIds` after editing the election JSON.