### PR TITLE
Error message is not shown on Chrome (Ceremony)

### DIFF
--- a/avAdmin/admin-directives/dashboard/delete-share-ceremony-modal.js
+++ b/avAdmin/admin-directives/dashboard/delete-share-ceremony-modal.js
@@ -52,7 +52,7 @@ angular.module('avAdmin')
           ).catch(
             function (error)
             {
-              $scope.error = error.statusText;
+              $scope.error = error.statusText || error.status;
             }
           );
         });

--- a/avAdmin/admin-directives/dashboard/download-share-ceremony-modal.js
+++ b/avAdmin/admin-directives/dashboard/download-share-ceremony-modal.js
@@ -49,7 +49,7 @@ angular.module('avAdmin')
         ).catch(
           function(error)
           {
-            $scope.error = error.statusText;
+            $scope.error = error.statusText || error.status;
           }
         );
       };

--- a/avAdmin/admin-directives/dashboard/login-trustee-ceremony-modal.js
+++ b/avAdmin/admin-directives/dashboard/login-trustee-ceremony-modal.js
@@ -56,6 +56,16 @@ angular.module('avAdmin')
         return field && field.value;
       }
 
+      function getErrorText(error) {
+        if (error.statusText) {
+          return error.statusText;
+        }
+        if (error.status === 401) {
+          return "Unauthorized";
+        }
+        return error.status + "";
+      }
+
       $scope.login = function () {
         resetErrorMessages();
 
@@ -74,7 +84,7 @@ angular.module('avAdmin')
         ).catch(
           function(error)
           {
-            $scope.error = error.statusText;
+            $scope.error = getErrorText(error);
           }
         );
       };

--- a/avAdmin/admin-directives/dashboard/restore-share-ceremony-modal.js
+++ b/avAdmin/admin-directives/dashboard/restore-share-ceremony-modal.js
@@ -45,13 +45,13 @@ angular.module('avAdmin')
               if (200 === result.status) {
                 $scope.showSuccess = true;
               } else {
-                $scope.error = result.statusText;
+                $scope.error = result.statusText || error.status;
               }
             }
           ).catch(
             function (error)
             {
-              $scope.error = error.statusText;
+              $scope.error = error.statusText || error.status;
             }
           );
         });

--- a/avAdmin/admin-directives/dashboard/restore-share-ceremony-modal.js
+++ b/avAdmin/admin-directives/dashboard/restore-share-ceremony-modal.js
@@ -45,7 +45,7 @@ angular.module('avAdmin')
               if (200 === result.status) {
                 $scope.showSuccess = true;
               } else {
-                $scope.error = result.statusText || error.status;
+                $scope.error = result.statusText || result.status;
               }
             }
           ).catch(


### PR DESCRIPTION
Http requests in Chrome can have empty `statusText` fields. This means error messages are not shown in the ceremonies on Chrome.