### PR TITLE
Live preview  (#323)

### DIFF
--- a/avAdmin/admin-directives/create/create.html
+++ b/avAdmin/admin-directives/create/create.html
@@ -1,8 +1,34 @@
 <div>
-    <h2>
-      <span ng-i18next>[i18next]({'num': elections.length})avAdmin.create.summary</span>
-      <i class="fa fa-pencil" ng-click="editJson()" ng-if="allowEditElectionJson"></i>
-    </h2>
+    <div class="container-fluid">
+      <div class="dropdown pull-left">
+        <h2>
+          <span ng-i18next>[i18next]({'num': elections.length})avAdmin.create.summary</span>
+        </h2>
+      </div>
+      <div class="dropdown pull-right actions-div">
+        <button
+          class="btn btn-success actionbtn ng-scope btn-primary dropdown-toggle"
+          type="button"
+          data-toggle="dropdown"
+          aria-expanded="false"
+        >
+          <span ng-i18next>avAdmin.create.actions.actionsLabel</span>
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+          <li
+            ng-repeat="action in actions"
+            ng-class="{'disabled': !action.enableFunc()}">
+            <a ng-click="action.enableFunc() && action.actionFunc()">
+              <i class="{{action.iconClass}}"></i>
+              <span ng-i18next>
+                [i18next]avAdmin.create.actions.{{action.i18nString}}
+              </span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
 
     <div ng-repeat="election in elections">
       <h3 ng-i18next>[i18next]({'title': election.title, 'index': $index+1})avAdmin.basic.title.labelH3</h3>

--- a/avAdmin/admin-directives/create/create.less
+++ b/avAdmin/admin-directives/create/create.less
@@ -35,4 +35,12 @@
       margin-top: -8px;
     }
   }
+
+  .actions-div {
+    margin-top: 20px;
+  }
+  
+  .dropdown-menu i {
+    padding-right: 6px;
+  }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -898,12 +898,18 @@
         "reg": "Registering the election (id: __id__) __title__",
         "creatingEl": "Creating election (id: __id__) __title__",
         "logHeader": "Log",
+        "actions": {
+          "actionsLabel": "Actions",
+          "editJson": "Edit JSON",
+          "livePreview": "Live Preview"
+        },
         "editElectionJsonModal": {
           "title": "Edit Election Json",
           "body": "This dialog allows you to edit the election json. Use this only if you know what you are doing.",
           "confirmEdit": "Finish edit"
         },
         "errors": {
+          "lambda-live-preview-parent-children": "Missing election IDs for a parent-children election",
           "election-is-array-questions": "Election '__eltitle__': list of questions is not an array",
           "election-lambda-success-action-url-mode": "Election '__eltitle__': invalid success action url",
           "election-lambda-min-email-msg": "Election '__eltitle__': email message length is __len__ characters, but it has to be at least __min__ characters long",

--- a/locales/es.json
+++ b/locales/es.json
@@ -814,7 +814,13 @@
         "reg": "Registrando la votación (id: __id__) __title__",
         "creatingEl": "Creando la votación (id: __id__) __title__",
         "logHeader": "Log",
+        "actions": {
+          "actionsLabel": "Acciones",
+          "editJson": "Editar JSON",
+          "livePreview": "Previsualización en vivo"
+        },
         "errors": {
+          "lambda-live-preview-parent-children": "Faltan ID de la votación para una votación padre-hijos",
           "election-is-array-questions": "Votación '__eltitle__': la lista de pregunta no es un array",
           "election-lambda-success-action-url-mode": "Votación '__eltitle__': url de redirección en 'Acción de éxito' inválida",
           "election-lambda-min-email-msg": "Votación '__eltitle__': el mensaje de email tiene una longitud de __len__ caracteres, pero debe tener al menos __min__",


### PR DESCRIPTION
This PR adds the ability to open the live preview for an election before creating the election.

# Changes

* In the last step of the election creation, the pencil button for editing the election json is removed.
* Instead, an actions dropdown menu is added, with two options: Edit JSON and Live Preview.
* When the Live Preview option is clicked, the Election creation JSON is stored in `sessionStorage` and the live preview voting booth is opened in another tab.
* Parent-children elections must define the election ids. A check has been added and an error is shown in the case the ids are missing. If there's an error checking the election creation Json, the Live Preview option will become unavailable.
* As the data passed to the voting booth is the Election creation JSON, the process of converting that JSON into the JSON of an already created JSON will also be used in the voting booth. That code is moved to the `common-ui` to be shared with the voting booth.