### PR TITLE
Election IDs automation (#330)

### DIFF
--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -1227,6 +1227,94 @@ angular.module('avAdmin')
           deferred.resolve(scope.elections[electionIndex]);
         }
 
+        /**
+         * If the elections are using negative numbers, find the existing election
+         * with the highest election id and replace the negative numbers with
+         * higher election ids.
+         */
+        function fillInElectionIds(elections) {
+          var deferred = $q.defer();
+          var promise = deferred.promise;
+
+          // check if there are negative election ids
+          var hasNegativeIds = undefined !== elections.find(function (el) {
+            return _.isNumber(el.id) && el.id <= 0;
+          });
+
+          /* jshint ignore:start */
+
+          if (elections.length > 1 || hasNegativeIds) {
+
+            // Find highest election id
+            Authmethod.highestEvent()
+                .then(
+                  function onSuccess(response) {
+                    var highestId = response.data.highest_id;
+                    var newIdsMap = {};
+
+                    // map negative ids to new election ids
+                    for (var idx = 0; idx < elections.length; idx++) {
+                      var electionId = elections[idx].id;
+                      if (_.isNumber(electionId) && electionId > 0) {
+                        newIdsMap[electionId] = electionId;
+                      } else {
+                        newIdsMap[electionId] = highestId + idx + 1;
+                      }
+                    }
+
+                    // replace election ids with new ids
+                    for (var index = 0; index < elections.length; index++) {
+                      var election = elections[index];
+                      // replace the election id
+                      election.id = newIdsMap[election.id];
+
+                      // replace the parent id
+                      if (election.parent_id) {
+                        election.parent_id = newIdsMap[election.parent_id] || election.parent_id;
+                      }
+
+                      // replace ids for virtualSubelections
+                      if (election.virtualSubelections) {
+                        election.virtualSubelections = election.virtualSubelections.map(function (e) {
+                          return newIdsMap[e] || e;
+                        });
+                      }
+
+                      // replace ids in the children elections structure
+                      if (election.children_election_info &&
+                          election.children_election_info.natural_order) {
+                        election.children_election_info.natural_order = election.children_election_info.natural_order.map(function (e) {
+                          return newIdsMap[e] || e;
+                        });
+                      }
+                      if (election.children_election_info &&
+                        election.children_election_info.presentation &&
+                        election.children_election_info.presentation.categories) {
+                          election.children_election_info.presentation.categories = 
+                          election.children_election_info.presentation.categories.map(function (category) {
+                            if (category.events) {
+                              category.events = category.events.map(function (event) {
+                                if (event.event_id) {
+                                  event.event_id = newIdsMap[event.event_id] || event.event_id;
+                                }
+                                return event;
+                              });
+                            }
+                            return category;
+                          });
+                      }
+                    }
+                    deferred.resolve(elections);
+                  },
+                  deferred.reject
+                );
+          } else {
+            deferred.resolve(elections);
+          }
+          /* jshint ignore:end */
+          return promise;
+        }
+
         function addElection(electionIndex) 
         {
           var deferred = $q.defer();
@@ -1289,7 +1377,13 @@ angular.module('avAdmin')
             .result.then(
               function (data)
               {
-                scope.elections = angular.fromJson(data.electionJson);
+                var elections = angular.fromJson(data.electionJson);
+                return fillInElectionIds(elections);
+              }
+            ).then(
+              function (data)
+              {
+                scope.elections = data;
 
                 scope.errors = [];
                 CheckerService({


### PR DESCRIPTION
Automate filling in election IDs. If the election ID in the Election JSON is negative, replace it with new Election IDs.

# Changes
* Add new method `fillInElectionIds`. The method detects wether there's any election ID with negative numbers, if there isn't any it returns the election json unmodified.
* If there is a negative election ID, make a call to the auth api (IAM) to find out the highest existing election ID. Use that to replace the negative election IDs with new election IDs.
* Call the new method `fillInElectionIds` after editing the election JSON.