### PR TITLE
Census admin doesn't login correctly if loaded directly

### DIFF
--- a/avAdmin/admin-directives/elcensus/elcensus.js
+++ b/avAdmin/admin-directives/elcensus/elcensus.js
@@ -1196,6 +1196,8 @@ angular.module('avAdmin')
         scope.election = ElectionsApi.currentElection;
         MustExtraFieldsService(scope.election);
         if (scope.page === 1 && !newElection()) {
+          // assign the election id that somehow is not assigned before
+          scope.election.id = $stateParams.id;
           reloadCensus();
         }
       }


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/64

## Problem description

In the admin portal, when the census tab of an election is loaded directly (instead of arriving there by clicking from another screen), it shows a scary red error.

## Proposed Solution

Fix it so that this scary error does not show, and the system loads the election census correctly instead.