### PR TITLE
Fix start ceremony

### DIFF
--- a/avAdmin/admin-directives/dashboard/dashboard.js
+++ b/avAdmin/admin-directives/dashboard/dashboard.js
@@ -979,6 +979,14 @@ angular.module('avAdmin')
                 (
                   scope.perms.val.indexOf("start") !== -1 ||
                   scope.perms.val.indexOf("edit") !== -1
+                ) &&
+                (
+                  !scope.election.presentation ||
+                  !scope.election.presentation.election_board_ceremony ||
+                  (
+                    !!scope.election.trusteeKeysState &&
+                    scope.election.trusteeKeysState.every(function (e) { return e.state === 'deleted'; })
+                  )
                 )
               );
             }


### PR DESCRIPTION
Parent issue: #351 

## Problem description

When `election.presentation.election_board_ceremony` is set to `true`, the `start election` action in the election dashboard breadcrumb does not allow to start the election unless the Key Distribution Ceremony has been executed. However, the `Start election` action in the Actions menu does allow it.

This can generate a situation in which votes have been cast, the key distribution ceremony has not been executed, and tally cannot be launched since that action does require also to have executed the election board ceremonies (both key distribution and opening).

## Proposed Solution

Change the `Start election` action in the Actions menu in the Election Dashboard so that it also requires to execute the Key Distribution Ceremony before allowing to start the election when `election.presentation.election_board_ceremony` is set to `true`.
