### PR TITLE
Unify tallying procedures (#357)

### DIFF
--- a/avAdmin/admin-directives/dashboard/confirm-tally-modal.html
+++ b/avAdmin/admin-directives/dashboard/confirm-tally-modal.html
@@ -13,11 +13,21 @@
     <span ng-i18next>
       [html]avAdmin.dashboard.modals.tallyIntro
     </span>
-
-    <a href="{{helpurl}}" class="learn-more" target="_blank" ng-i18next>
-      avAdmin.learnMore
-    </a>
   </p>
+
+  <div
+    ng-if="children_election_info && children_election_info.presentation && children_election_info.presentation.categories && children_election_info.presentation.categories.length > 0"
+    class="active-mode-settings">
+    <br/>
+    <span class="description" ng-i18next>
+      avAdmin.dashboard.modals.censusDumpMode.chooseChildrenToTally
+    </span>
+    <div
+      av-children-elections
+      mode="checkbox"
+      children-election-info="children_election_info">
+    </div>
+  </div>
 
   <!-- Show forms of census dump -->
   <div class="form-group">
@@ -48,33 +58,7 @@
         class="description"
         ng-i18next="[html]avAdmin.dashboard.modals.censusDumpMode.{{ mode.name }}Description">
       </span>
-
-      <div
-        ng-if="mode.name == 'active' && children_election_info && children_election_info.presentation && children_election_info.presentation.categories && children_election_info.presentation.categories.length > 0"
-        class="active-mode-settings">
-        <br/>
-        <span class="description" ng-i18next>
-          avAdmin.dashboard.modals.censusDumpMode.chooseChildrenToTally
-        </span>
-        <div
-          av-children-elections
-          mode="checkbox"
-          children-election-info="children_election_info">
-        </div>
-      </div>
     </label>
-  </div>
-  <div class="row-fluid">
-    <div class="col-xs-12">
-      <progressbar
-        ng-if="downloading"
-        class="progress-striped active"
-        max="totalCensusCount"
-        value="currentCount"
-        type="success">
-        <strong>{{currentCount}} / {{totalCensusCount}}</strong>
-      </progressbar>
-    </div>
   </div>
 </div>
 <div class="modal-footer">

--- a/avAdmin/admin-directives/dashboard/confirm-tally-modal.js
+++ b/avAdmin/admin-directives/dashboard/confirm-tally-modal.js
@@ -51,17 +51,17 @@ angular.module('avAdmin')
 
       $scope.census_dump_modes = [
         {
-          name: 'all',
+          name: 'active',
           enabled: true
         },
         {
-          name: 'active',
+          name: 'all',
           enabled: true
-        }
+        },
       ];
 
       $scope.binding = {
-        census_dump_mode: 'all'
+        census_dump_mode: 'active'
       };
 
       $scope.ok = function () {

--- a/avAdmin/admin-directives/dashboard/dashboard.js
+++ b/avAdmin/admin-directives/dashboard/dashboard.js
@@ -800,14 +800,18 @@ angular.module('avAdmin')
               scope.intally = true;
               scope.index = scope.getStatusIndex('stopped') + 1;
               scope.nextaction = false;
-
-              if (data.mode === 'all') {
-                ElectionsApi.command(
-                  scope.election,
-                  command.path,
-                  command.method,
-                  command.data
-                ).catch(
+              Authmethod
+                .launchTally(
+                  scope.election.id,
+                  data.tallyElectionIds,
+                  'force-all',
+                  data.mode
+                )
+                .then(
+                  function onSuccess() 
+                  {
+                    scope.msg = "avAdmin.dashboard.modals.launchTallySuccess";
+                  },
                   function(error)
                   {
                     if (scope.launchedTally) {
@@ -817,30 +821,6 @@ angular.module('avAdmin')
                     scope.error = error;
                   }
                 );
-
-              // tally only active users
-              } else {
-                Authmethod
-                  .launchTally(
-                    scope.election.id,
-                    data.tallyElectionIds,
-                    'force-all'
-                  )
-                  .then(
-                    function onSuccess() 
-                    {
-                      scope.msg = "avAdmin.dashboard.modals.launchTallySuccess";
-                    },
-                    function(error)
-                    {
-                      if (scope.launchedTally) {
-                        scope.launchedTally = false;
-                      }
-                      scope.loading = false;
-                      scope.error = error;
-                    }
-                  );
-              }
             },
             enableFunc: function () {
               return (


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/65

- Problem description

Admin console shows two possible avenues for launching the tally: tally all votes and tally active users. But they work very differently, one works with parent-children elections (tally active votes) and the other doesn't.

However this inconvenience is not reflected in the UI. To make things worse, the default selected method is the tally all votes, even for parent-children elections which don't work with that mode.

- Proposed solution

Make both modes (tally all census and tally active voters) work with parent-children elections and make the tally active voters the default.

- Tasks

- Change the `admin-console` to show differently the launch-tally dialog to allow selecting which children elections to choose for both modes.
  - Change the `admin-console` to request the tally always to the IAM.